### PR TITLE
Fixed AttributeError in TableEncryptionService.py

### DIFF
--- a/baad/lib/TableEncryptionService.py
+++ b/baad/lib/TableEncryptionService.py
@@ -23,11 +23,11 @@ class TableEncryptionService:
 
     def create_key(self, name: str) -> bytes:
         seed = calculate_hash(name)
-        return MersenneTwister(seed).next_bytes(8)
+        return MersenneTwister(seed).NextBytes(8)
 
     def xor(self, name: str, data: bytes) -> bytes:
         seed = calculate_hash(name)
-        key = MersenneTwister(seed).next_bytes(len(data))
+        key = MersenneTwister(seed).NextBytes(len(data))
         return self._xor(data, key) if data else data
 
     def _xor(self, value: bytes, key: bytes) -> bytes:


### PR DESCRIPTION
Update TableEncryptionService.py
Changed next_bytes to NextBytes in line26 and 30


original bug:
File "C:\Users\123\AppData\Roaming\uv\tools\ba-ad\Lib\site-packages\baad\lib\TableEncryptionService.py", line 26, in create_key
    return MersenneTwister(seed).next_bytes(8)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'MersenneTwister' object has no attribute 'next_bytes'. Did you mean: 'NextBytes'?